### PR TITLE
Chorer: upgrade @kusithms.com/ui and tokens to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@kusitms.com/icons": "^0.1.0",
-    "@kusitms.com/tokens": "^0.1.0",
-    "@kusitms.com/ui": "^0.1.0",
+    "@kusitms.com/tokens": "^0.2.0",
+    "@kusitms.com/ui": "^0.2.0",
     "@next/third-parties": "^16.0.1",
     "@radix-ui/react-slot": "^1.2.2",
     "@vercel/speed-insights": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(react@19.1.0)
       '@kusitms.com/tokens':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.0
+        version: 0.2.0
       '@kusitms.com/ui':
-        specifier: ^0.1.0
-        version: 0.1.0(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^0.2.0
+        version: 0.2.0(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next/third-parties':
         specifier: ^16.0.1
         version: 16.0.1(next@16.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -348,11 +348,11 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
-  '@kusitms.com/tokens@0.1.0':
-    resolution: {integrity: sha512-wnegma1ujsWzTLjhGItXFQVIIxfCjYTze4MNtL5c89rvcsC5QUrMk0qa7LSU2G117LuV+Yow+Ig37J+CJCQqBw==}
+  '@kusitms.com/tokens@0.2.0':
+    resolution: {integrity: sha512-9I8Gw8FXdK5I49UMg7GakOFIqLRt50XabY5L8TGcwqywdCPivk1b0x1e2OrowLj8wGKS0ktGN8KDxUoLOe5RAg==}
 
-  '@kusitms.com/ui@0.1.0':
-    resolution: {integrity: sha512-iLzHJo4u9liLTIysgKbQF6f7JsZuqfdxVL6Fzmu/KbYU8uD8UGQQ3ibDTkrCekef4aaf6Ekh/4diqtX7BnUi/w==}
+  '@kusitms.com/ui@0.2.0':
+    resolution: {integrity: sha512-39iUIjhUsvZYO6c8DCtAzrrOocidgbGOF84l4VgZR+aWfzzwSMUM8Lwp78Djyx0ynYSMA912CcT/kOYWjNRYTg==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -1372,10 +1372,12 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  '@kusitms.com/tokens@0.1.0': {}
+  '@kusitms.com/tokens@0.2.0': {}
 
-  '@kusitms.com/ui@0.1.0(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@kusitms.com/ui@0.2.0(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
+      '@kusitms.com/icons': 0.1.0(react@19.1.0)
+      '@kusitms.com/tokens': 0.2.0
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select': 2.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,7 @@
-@import "@kusitms.com/ui/styles.css";
-
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@import "@kusitms.com/ui/source.css";
 @import "@kusitms.com/tokens/index.css";
 @import "@kusitms.com/tokens/themes.css";
 @import "@kusitms.com/tokens/typography.css";
@@ -201,7 +200,6 @@ body {
 }
 
 @theme {
-  --breakpoint-*: initial;
   --breakpoint-tablet: 768px;
   --breakpoint-desktop: 1024px;
   --breakpoint-wide: 1440px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

`@kusitms.com/ui`, `@kusitms.com/tokens` 패키지를 0.1.0 → 0.2.0으로 업그레이드합니다.

- `@kusitms.com/ui` 0.1.0 → 0.2.0
- `@kusitms.com/tokens` 0.1.0 → 0.2.0
- CSS import 경로 변경: `styles.css` → `source.css` (0.2.0 패키지 구조 변경 대응)
- `globals.css`에서 `--breakpoint-*: initial` 제거 — UI 패키지 내부에서 Tailwind 기본 브레이크포인트(`lg` 등)를 사용하므로 리셋 불필요

### 스크린샷 (선택)
<img width="1915" height="958" alt="image" src="https://github.com/user-attachments/assets/d2327c0f-545e-419a-833b-08d719da6915" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

`--breakpoint-*: initial` 제거로 인해 Tailwind 기본 브레이크포인트(`sm`, `md`, `lg` 등)가 프로젝트에서도 활성화됩니다. 기존 코드에서 의도치 않게 기본 브레이크포인트가 적용되는 케이스가 없는지 확인 부탁드립니다.