### PR TITLE
Feature: /mypage/ob 일정 등록 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "4.4.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.6.3",
     "lucide-react": "^0.511.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: 4.4.0
+        version: 4.4.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
@@ -123,28 +126,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.6':
     resolution: {integrity: sha512-BpGtuMJGN+o8pQjvYsUKZ+4JEErxdSmcRD/JG3mXoWc6zrcA7OkuyGFN1mDggO0Q1n7qXxo/PcupHk8gzijt5g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.6':
     resolution: {integrity: sha512-1ZcBux8zVM3JhWN2ZCPaYf0+ogxXG316uaoXJdgoPZcdK/rmRcRY7PqHdAos2ExzvjIdvhQp72UcveI98hgOog==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.6':
     resolution: {integrity: sha512-1HaM/dpI/1Z68zp8ZdT6EiBq+/O/z97a2AiHMl+VAdv5/ELckFt9EvRb8hDHpk8hUMoz03gXkC7VPXOVtU7faA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.6':
     resolution: {integrity: sha512-h3A88G8PGM1ryTeZyLlSdfC/gz3e95EJw9BZmA6Po412DRqwqPBa2Y9U+4ZSGUAXCsnSQE00jLV8Pyrh0d+jQw==}
@@ -206,105 +205,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -380,28 +363,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.0.7':
     resolution: {integrity: sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.0.7':
     resolution: {integrity: sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.0.7':
     resolution: {integrity: sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.0.7':
     resolution: {integrity: sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==}
@@ -753,28 +732,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -868,6 +843,9 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
@@ -950,28 +928,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1800,6 +1774,8 @@ snapshots:
   countup.js@2.9.0: {}
 
   csstype@3.1.3: {}
+
+  date-fns@4.4.0: {}
 
   detect-libc@2.0.4: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,26 @@ body {
   scrollbar-width: none; /* Firefox에서 스크롤바 숨기기 */
 }
 
+/* @kusitms.com/ui Dropdown: 긴 Radix Select 옵션 목록은 패널 안에서 스크롤 */
+[role="listbox"][data-state="open"][style*="--radix-select-trigger-width"] {
+  max-height: min(320px, var(--radix-select-content-available-height));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+[role="listbox"][data-state="open"][style*="--radix-select-trigger-width"]::-webkit-scrollbar {
+  width: 6px;
+}
+
+[role="listbox"][data-state="open"][style*="--radix-select-trigger-width"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[role="listbox"][data-state="open"][style*="--radix-select-trigger-width"]::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: #c1c6d3;
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/app/mypage/ob/schedule/page.tsx
+++ b/src/app/mypage/ob/schedule/page.tsx
@@ -1,0 +1,5 @@
+import { ObScheduleContainer } from "@/components/mypage/ob/schedule/ObScheduleContainer";
+
+export default function ObSchedulePage() {
+  return <ObScheduleContainer />;
+}

--- a/src/components/mypage/ob/ObMentoringPresenter.tsx
+++ b/src/components/mypage/ob/ObMentoringPresenter.tsx
@@ -1,5 +1,4 @@
 import { SaveSuccessModal } from "@/components/mypage/ob/components/feedback/SaveSuccessModal";
-import { SaveToast } from "@/components/mypage/ob/components/feedback/SaveToast";
 import { FormActions } from "@/components/mypage/ob/components/form/FormActions";
 import { MyPageHeader } from "@/components/mypage/ob/components/layout/MyPageHeader";
 import { ProfileSummary } from "@/components/mypage/ob/components/layout/ProfileSummary";
@@ -9,6 +8,7 @@ import { BasicInfoSection } from "@/components/mypage/ob/components/sections/Bas
 import { MentoringIntroSection } from "@/components/mypage/ob/components/sections/MentoringIntroSection";
 import { MentoringMethodSection } from "@/components/mypage/ob/components/sections/MentoringMethodSection";
 import type { ObMentoringPresenterProps } from "@/components/mypage/ob/types";
+import { SuccessToast } from "@/components/shared/ui/SuccessToast";
 
 export function ObMentoringPresenter({
   form,
@@ -52,7 +52,7 @@ export function ObMentoringPresenter({
       {modalVisible && (
         <SaveSuccessModal onClose={handleCloseModal} onConfirm={handleConfirmModal} />
       )}
-      {toastVisible && <SaveToast />}
+      {toastVisible && <SuccessToast />}
     </main>
   );
 }

--- a/src/components/mypage/ob/components/layout/SideNav.tsx
+++ b/src/components/mypage/ob/components/layout/SideNav.tsx
@@ -1,7 +1,12 @@
 import { LogOut, User } from "lucide-react";
+import Link from "next/link";
 import { sideNavItems } from "@/components/mypage/ob/constants";
 
-export function SideNav() {
+type SideNavProps = {
+  activeItem?: string;
+};
+
+export function SideNav({ activeItem = "멘토링 관리" }: SideNavProps) {
   return (
     <aside className="hidden w-64 shrink-0 flex-col self-stretch border-r border-[#e5e7ef] bg-white py-10 text-sm desktop:flex">
       <div className="mb-7 flex items-center gap-3 px-5">
@@ -14,18 +19,24 @@ export function SideNav() {
         </div>
       </div>
       <nav className="space-y-1 px-3">
-        {sideNavItems.map(({ label, icon: Icon, active }) => (
-          <button
-            key={label}
-            type="button"
-            className={`flex h-12 w-full cursor-pointer items-center gap-3 rounded-md px-4 text-left font-semibold ${
-              active ? "bg-[#eef3ff] text-[#3157ff]" : "text-[#626879] hover:bg-[#f7f8fb]"
-            }`}
-          >
-            <Icon size={16} />
-            {label}
-          </button>
-        ))}
+        {sideNavItems.map(({ label, icon: Icon, href }) => {
+          const active = label === activeItem;
+          const className = `flex h-12 w-full cursor-pointer items-center gap-3 rounded-md px-4 text-left font-semibold ${
+            active ? "bg-[#eef3ff] text-[#3157ff]" : "text-[#626879] hover:bg-[#f7f8fb]"
+          }`;
+
+          return href ? (
+            <Link key={label} href={href} className={className}>
+              <Icon size={16} />
+              {label}
+            </Link>
+          ) : (
+            <button key={label} type="button" className={className}>
+              <Icon size={16} />
+              {label}
+            </button>
+          );
+        })}
       </nav>
       <button
         type="button"

--- a/src/components/mypage/ob/constants.ts
+++ b/src/components/mypage/ob/constants.ts
@@ -24,8 +24,8 @@ export const initialForm: ObMentoringFormState = {
 };
 
 export const sideNavItems: SideNavItem[] = [
-  { label: "멘토링 관리", icon: User, active: true },
-  { label: "일정 등록", icon: Clock3 },
+  { label: "멘토링 관리", icon: User, href: "/mypage/ob" },
+  { label: "일정 등록", icon: Clock3, href: "/mypage/ob/schedule" },
   { label: "멘토링 내역", icon: FileText },
   { label: "채팅방", icon: MessageSquare },
   { label: "받은 후기", icon: Heart },

--- a/src/components/mypage/ob/schedule/ObScheduleContainer.tsx
+++ b/src/components/mypage/ob/schedule/ObScheduleContainer.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useObSchedule } from "@/components/mypage/ob/schedule/hooks/useObSchedule";
+import { ObSchedulePresenter } from "@/components/mypage/ob/schedule/ObSchedulePresenter";
+
+export function ObScheduleContainer() {
+  const schedule = useObSchedule();
+
+  return <ObSchedulePresenter {...schedule} />;
+}

--- a/src/components/mypage/ob/schedule/ObSchedulePresenter.tsx
+++ b/src/components/mypage/ob/schedule/ObSchedulePresenter.tsx
@@ -1,0 +1,43 @@
+import { MyPageHeader } from "@/components/mypage/ob/components/layout/MyPageHeader";
+import { ProfileSummary } from "@/components/mypage/ob/components/layout/ProfileSummary";
+import { SideNav } from "@/components/mypage/ob/components/layout/SideNav";
+import { ScheduleCalendar } from "@/components/mypage/ob/schedule/components/ScheduleCalendar";
+import { ScheduleControlPanel } from "@/components/mypage/ob/schedule/components/ScheduleControlPanel";
+import type { UseObScheduleReturn } from "@/components/mypage/ob/schedule/types";
+import { SuccessToast } from "@/components/shared/ui/SuccessToast";
+
+export function ObSchedulePresenter({
+  calendar,
+  dateNav,
+  timeSlot,
+  groupMentoring,
+  register,
+}: UseObScheduleReturn) {
+  return (
+    <main className="min-h-screen bg-white font-[family-name:var(--font-pretendard)] text-[#151519]">
+      <MyPageHeader />
+      <div className="mx-auto flex w-full max-w-[1200px] gap-6 px-5 desktop:px-0">
+        <SideNav activeItem="일정 등록" />
+        <div className="min-w-0 flex-1 space-y-5 py-8">
+          <ProfileSummary />
+          <div>
+            <h1 className="text-[28px] font-bold leading-9 text-[#151519]">일정 등록</h1>
+            <p className="mt-2 text-base font-medium leading-6 text-[#737889]">
+              멘토링을 진행할 날짜와 시간대를 등록해 주세요.
+            </p>
+          </div>
+          <div className="grid items-start gap-5 desktop:grid-cols-[minmax(0,1fr)_384px]">
+            <ScheduleCalendar calendar={calendar} />
+            <ScheduleControlPanel
+              dateNav={dateNav}
+              timeSlot={timeSlot}
+              groupMentoring={groupMentoring}
+              register={register}
+            />
+          </div>
+        </div>
+      </div>
+      {register.toastVisible && <SuccessToast message="일정이 등록되었습니다." />}
+    </main>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/GroupMentoringControl.tsx
+++ b/src/components/mypage/ob/schedule/components/GroupMentoringControl.tsx
@@ -1,0 +1,90 @@
+import { Minus, Plus } from "lucide-react";
+import type { ReactNode } from "react";
+import type { ScheduleGroupMentoringModel } from "@/components/mypage/ob/schedule/types";
+
+type GroupMentoringControlProps = {
+  groupMentoring: ScheduleGroupMentoringModel;
+};
+
+export function GroupMentoringControl({ groupMentoring }: GroupMentoringControlProps) {
+  return (
+    <div className="px-5 pt-7">
+      <div className="flex h-[40px] items-start justify-between">
+        <div>
+          <p className="text-sm font-semibold leading-[18px] text-[#626879]">1:N 멘토링</p>
+          <p className="mt-1 text-sm font-medium leading-[18px] text-[#b1b6c3]">
+            소그룹 멘토링을 신청하는 경우 체크해주세요
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={groupMentoring.isGroupMentoring}
+          onClick={groupMentoring.toggleGroupMentoring}
+          className={`relative mt-0.5 h-[18px] w-8 shrink-0 cursor-pointer rounded-full transition ${
+            groupMentoring.isGroupMentoring ? "bg-[#3157ff]" : "bg-[#d9dce3]"
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 size-3.5 rounded-full bg-white transition ${
+              groupMentoring.isGroupMentoring ? "left-4" : "left-0.5"
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className="mt-4 grid h-10 grid-cols-[40px_minmax(0,1fr)_40px] gap-2">
+        <CapacityButton
+          label="인원 줄이기"
+          disabled={!groupMentoring.isGroupMentoring || groupMentoring.capacity <= 1}
+          onClick={groupMentoring.decrementCapacity}
+        >
+          <Minus size={14} />
+        </CapacityButton>
+        <div
+          className={`flex items-center justify-center rounded-[8px] border border-[#d9dce3] text-sm font-semibold ${
+            groupMentoring.isGroupMentoring
+              ? "bg-white text-[#343946]"
+              : "bg-[#fafbfc] text-[#9da2af]"
+          }`}
+        >
+          {groupMentoring.isGroupMentoring
+            ? `${groupMentoring.capacity}명`
+            : `최대 ${groupMentoring.capacity}명`}
+        </div>
+        <CapacityButton
+          label="인원 늘리기"
+          disabled={!groupMentoring.isGroupMentoring || groupMentoring.capacity >= 5}
+          onClick={groupMentoring.incrementCapacity}
+        >
+          <Plus size={14} />
+        </CapacityButton>
+      </div>
+    </div>
+  );
+}
+
+type CapacityButtonProps = {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  children: ReactNode;
+};
+
+function CapacityButton({ label, disabled, onClick, children }: CapacityButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={`grid size-10 place-items-center rounded-[8px] ${
+        disabled
+          ? "cursor-not-allowed bg-[#eef0f6] text-[#626879]"
+          : "cursor-pointer bg-[#eef3ff] text-[#3157ff] hover:bg-[#e3ebff]"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/ScheduleCalendar.tsx
+++ b/src/components/mypage/ob/schedule/components/ScheduleCalendar.tsx
@@ -1,0 +1,83 @@
+import { format } from "date-fns";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { weekdayLabels } from "@/components/mypage/ob/schedule/constants";
+import type { ScheduleCalendarModel } from "@/components/mypage/ob/schedule/types";
+
+type ScheduleCalendarProps = {
+  calendar: ScheduleCalendarModel;
+};
+
+export function ScheduleCalendar({ calendar }: ScheduleCalendarProps) {
+  return (
+    <section className="h-[580px] overflow-hidden rounded-b-[16px] bg-white">
+      <div className="flex h-[61px] items-center justify-between px-5">
+        <h2 className="text-xl font-bold leading-7 text-[#151519]">
+          {format(calendar.currentMonth, "yyyy년 M월")}
+        </h2>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={calendar.goToPrevMonth}
+            aria-label="이전 달"
+            className="grid size-9 cursor-pointer place-items-center rounded-[8px] text-[#b1b6c3] hover:bg-[#f7f8fb]"
+          >
+            <ChevronLeft size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={calendar.goToNextMonth}
+            aria-label="다음 달"
+            className="grid size-9 cursor-pointer place-items-center rounded-[8px] text-[#343946] hover:bg-[#f7f8fb]"
+          >
+            <ChevronRight size={18} />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid h-[35px] grid-cols-7 items-center text-center text-xs font-semibold text-[#626879]">
+        {weekdayLabels.map((label) => (
+          <div key={label} className={label === "일" ? "text-[#e5484d]" : undefined}>
+            {label}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7">
+        {calendar.calendarDays.map((day) => (
+          <button
+            key={day.dateKey}
+            type="button"
+            onClick={() => calendar.selectDate(day.date)}
+            className={`relative flex h-[96.8px] cursor-pointer flex-col border-t border-r border-[#f0f1f5] px-3 py-3 text-left text-sm transition nth-[7n]:border-r-0 ${
+              day.isSelected
+                ? "z-10 rounded-[4px] border !border-[#3E5EFA] bg-[#EFF4FF]"
+                : day.isCurrentMonth
+                  ? "bg-white hover:bg-[#fafbff]"
+                  : "bg-[#f7f7f9]"
+            }`}
+          >
+            <span
+              className={`flex items-center gap-1 font-medium leading-5 ${
+                day.isToday && !day.isSelected
+                  ? "text-[#3157ff]"
+                  : day.isSelected
+                    ? "text-[#343946]"
+                    : day.isCurrentMonth
+                      ? day.isSunday
+                        ? "text-[#e5484d]"
+                        : "text-[#343946]"
+                      : "text-[#c1c6d3]"
+              }`}
+            >
+              <span>{day.day}</span>
+              {day.isToday && <span className="text-xs font-medium leading-5">오늘</span>}
+            </span>
+            {day.hasSlots && (
+              <span className="absolute left-1/2 top-[78px] size-1.5 -translate-x-1/2 rounded-full bg-[#3157ff]" />
+            )}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/ScheduleControlPanel.tsx
+++ b/src/components/mypage/ob/schedule/components/ScheduleControlPanel.tsx
@@ -1,0 +1,117 @@
+import { ChevronLeft, ChevronRight, Clock3 } from "lucide-react";
+import type { ReactNode } from "react";
+import { GroupMentoringControl } from "@/components/mypage/ob/schedule/components/GroupMentoringControl";
+import { TimeDropdown } from "@/components/mypage/ob/schedule/components/TimeDropdown";
+import { TimeSlotList } from "@/components/mypage/ob/schedule/components/TimeSlotList";
+import type {
+  ScheduleDateNavModel,
+  ScheduleGroupMentoringModel,
+  ScheduleRegisterModel,
+  ScheduleTimeSlotModel,
+} from "@/components/mypage/ob/schedule/types";
+
+type ScheduleControlPanelProps = {
+  dateNav: ScheduleDateNavModel;
+  timeSlot: ScheduleTimeSlotModel;
+  groupMentoring: ScheduleGroupMentoringModel;
+  register: ScheduleRegisterModel;
+};
+
+export function ScheduleControlPanel({
+  dateNav,
+  timeSlot,
+  groupMentoring,
+  register,
+}: ScheduleControlPanelProps) {
+  return (
+    <aside className="relative min-h-[641px] overflow-hidden rounded-[16px] border border-[#e2e4eb] bg-white shadow-[0_1px_2px_rgba(16,24,40,0.04)]">
+      <div className="flex h-[61px] items-center border-b border-[#eef0f6] px-5">
+        <div className="flex items-center gap-2 text-sm font-semibold leading-5 text-[#343946]">
+          <Clock3 size={18} className="text-[#737889]" />
+          시간대 선택
+        </div>
+      </div>
+
+      <div className="pb-28">
+        <div className="flex h-[60px] items-center justify-between px-5">
+          <h2 className="text-lg font-bold leading-6 text-[#151519]">
+            {dateNav.selectedDateLabel}
+          </h2>
+          <div className="flex items-center gap-2">
+            <DateArrow label="이전 날짜" onClick={dateNav.selectPrevDate}>
+              <ChevronLeft size={20} />
+            </DateArrow>
+            <DateArrow label="다음 날짜" onClick={dateNav.selectNextDate}>
+              <ChevronRight size={20} />
+            </DateArrow>
+          </div>
+        </div>
+
+        <div className="px-5 pt-1">
+          <p className="mb-2 text-sm font-semibold leading-[18px] text-[#626879]">시간대 추가</p>
+          <div className="flex h-10 items-center gap-2">
+            <TimeDropdown
+              value={timeSlot.draftStartTime}
+              placeholder="시작 시간"
+              onChange={timeSlot.updateDraftStartTime}
+            />
+            <span className="text-sm font-semibold text-[#9da2af]">-</span>
+            <TimeDropdown
+              value={timeSlot.draftEndTime}
+              placeholder="종료 시간"
+              onChange={timeSlot.updateDraftEndTime}
+            />
+            <button
+              type="button"
+              onClick={timeSlot.addOrUpdateSlot}
+              disabled={!timeSlot.canSubmitSlot}
+              className={`h-10 w-[72px] shrink-0 rounded-[8px] text-sm font-bold ${
+                timeSlot.canSubmitSlot
+                  ? "cursor-pointer bg-[#eef3ff] text-[#3157ff] hover:bg-[#e3ebff]"
+                  : "cursor-not-allowed bg-[#eef0f6] text-[#626879]"
+              }`}
+            >
+              {timeSlot.editingSlotId ? "수정" : "추가"}
+            </button>
+          </div>
+        </div>
+        <TimeSlotList timeSlot={timeSlot} />
+        <GroupMentoringControl groupMentoring={groupMentoring} />
+      </div>
+
+      <div className="absolute inset-x-0 bottom-0 border-t border-[#eef0f6] bg-white/95 px-6 py-6">
+        <button
+          type="button"
+          onClick={register.registerSchedule}
+          disabled={!register.canRegister}
+          className={`h-12 w-full rounded-[8px] text-base font-bold ${
+            register.canRegister
+              ? "cursor-pointer bg-[#3157ff] text-white hover:bg-[#2447e8]"
+              : "cursor-not-allowed bg-[#eef0f6] text-[#626879]"
+          }`}
+        >
+          등록하기
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+type IconButtonProps = {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+};
+
+function DateArrow({ label, onClick, children }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className="grid size-7 cursor-pointer place-items-center rounded-full text-[#343946] hover:bg-[#f7f8fb]"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/TimeDropdown.tsx
+++ b/src/components/mypage/ob/schedule/components/TimeDropdown.tsx
@@ -1,0 +1,87 @@
+import { ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { formatDropdownTime } from "@/components/mypage/ob/schedule/components/timeFormat";
+import { timeOptions } from "@/components/mypage/ob/schedule/constants";
+
+type TimeDropdownProps = {
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+};
+
+const dropdownOptions = timeOptions.map((time) => ({
+  value: time,
+  label: formatDropdownTime(time),
+}));
+
+export function TimeDropdown({ value, placeholder, onChange }: TimeDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selectedLabel = value ? formatDropdownTime(value) : placeholder;
+
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, []);
+
+  const handleSelect = (nextValue: string) => {
+    onChange(nextValue);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={rootRef} className="relative min-w-0 flex-1">
+      <button
+        type="button"
+        aria-label={placeholder}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+        className={`flex h-10 w-full cursor-pointer items-center justify-between gap-2 rounded-[8px] border bg-[#fafbfc] px-3 text-left text-sm font-semibold leading-5 ${
+          open ? "border-[#3157ff] bg-white" : "border-[#d9dce3]"
+        } ${value ? "text-[#343946]" : "text-[#9da2af]"}`}
+      >
+        <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+          {selectedLabel}
+        </span>
+        <ChevronDown size={16} className="shrink-0 text-[#626879]" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 right-0 top-[44px] z-50 max-h-[220px] overflow-y-auto rounded-[8px] border border-[#d9dce3] bg-white p-1 shadow-[0_1px_10px_rgba(179,179,188,0.25)] overscroll-contain"
+        >
+          {dropdownOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="option"
+              aria-selected={option.value === value}
+              onClick={() => handleSelect(option.value)}
+              className={`flex h-10 w-full cursor-pointer items-center rounded-[6px] px-3 text-left text-sm leading-5 hover:bg-[#f4f5f8] ${
+                option.value === value
+                  ? "font-semibold text-[#3157ff]"
+                  : "font-medium text-[#343946]"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/TimeSlotList.tsx
+++ b/src/components/mypage/ob/schedule/components/TimeSlotList.tsx
@@ -1,0 +1,50 @@
+import { X } from "lucide-react";
+import { formatKoreanTime } from "@/components/mypage/ob/schedule/components/timeFormat";
+import type { ScheduleTimeSlotModel } from "@/components/mypage/ob/schedule/types";
+
+type TimeSlotListProps = {
+  timeSlot: ScheduleTimeSlotModel;
+};
+
+export function TimeSlotList({ timeSlot }: TimeSlotListProps) {
+  return (
+    <div className="px-5 pt-7">
+      <p className="text-sm font-semibold leading-[18px] text-[#626879]">설정된 시간대</p>
+      {timeSlot.selectedDateSlots.length > 0 ? (
+        <div className="mt-2 space-y-2">
+          {timeSlot.selectedDateSlots.map((slot) => (
+            <div
+              key={slot.id}
+              className="flex h-11 items-center justify-between rounded-[8px] bg-[#f7f7f9] px-3"
+            >
+              <span className="text-sm font-medium leading-5 text-[#151519]">
+                {formatKoreanTime(slot.startTime)} - {formatKoreanTime(slot.endTime)}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => timeSlot.startEditSlot(slot)}
+                  className="cursor-pointer px-1 text-xs font-medium leading-[18px] text-[#737889]"
+                >
+                  수정
+                </button>
+                <button
+                  type="button"
+                  onClick={() => timeSlot.removeSlot(slot.id)}
+                  aria-label="시간대 삭제"
+                  className="grid size-5 cursor-pointer place-items-center rounded-full text-[#9da2af] hover:bg-[#eef0f6]"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-sm font-medium leading-[18px] text-[#b1b6c3]">
+          시간대를 추가해주세요
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/mypage/ob/schedule/components/timeFormat.ts
+++ b/src/components/mypage/ob/schedule/components/timeFormat.ts
@@ -1,0 +1,10 @@
+export const formatKoreanTime = (time: string) => {
+  const [hourText, minuteText] = time.split(":");
+  const hour = Number(hourText);
+  const period = hour < 12 ? "오전" : "오후";
+  const displayHour = hour % 12 || 12;
+
+  return `${period} ${String(displayHour).padStart(2, "0")}:${minuteText}`;
+};
+
+export const formatDropdownTime = (time: string) => formatKoreanTime(time).replace(" 0", " ");

--- a/src/components/mypage/ob/schedule/constants.ts
+++ b/src/components/mypage/ob/schedule/constants.ts
@@ -1,0 +1,11 @@
+export const initialScheduleDate = new Date(2026, 5, 4);
+export const scheduleTodayDate = new Date(2026, 5, 1);
+
+export const weekdayLabels = ["일", "월", "화", "수", "목", "금", "토"];
+
+export const timeOptions = Array.from({ length: 24 * 6 }, (_, index) => {
+  const hour = Math.floor(index / 6);
+  const minute = (index % 6) * 10;
+
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+});

--- a/src/components/mypage/ob/schedule/hooks/useObSchedule.ts
+++ b/src/components/mypage/ob/schedule/hooks/useObSchedule.ts
@@ -1,0 +1,186 @@
+import { addDays, addMonths, format, getDay, isSameMonth, subMonths } from "date-fns";
+import { useMemo, useState } from "react";
+import { initialScheduleDate, weekdayLabels } from "@/components/mypage/ob/schedule/constants";
+import type {
+  ObScheduleState,
+  TimeSlot,
+  UseObScheduleReturn,
+} from "@/components/mypage/ob/schedule/types";
+import {
+  buildCalendarDays,
+  clearSlotDraft,
+  createSlotId,
+  dateKeyOf,
+} from "@/components/mypage/ob/schedule/utils";
+
+export function useObSchedule(): UseObScheduleReturn {
+  const [state, setState] = useState<ObScheduleState>({
+    currentMonth: initialScheduleDate,
+    selectedDate: initialScheduleDate,
+    slots: [],
+    draftStartTime: "",
+    draftEndTime: "",
+    editingSlotId: null,
+    isGroupMentoring: false,
+    capacity: 1,
+    toastVisible: false,
+  });
+
+  const selectedDateKey = dateKeyOf(state.selectedDate);
+
+  const calendarDays = useMemo(
+    () =>
+      buildCalendarDays({
+        currentMonth: state.currentMonth,
+        selectedDate: state.selectedDate,
+        slots: state.slots,
+      }),
+    [state.currentMonth, state.selectedDate, state.slots],
+  );
+
+  const selectedDateSlots = useMemo(
+    () => state.slots.filter((slot) => slot.dateKey === selectedDateKey),
+    [selectedDateKey, state.slots],
+  );
+
+  const selectedDateLabel = `${format(state.selectedDate, "M월 d일")} (${
+    weekdayLabels[getDay(state.selectedDate)]
+  })`;
+  const canSubmitSlot =
+    Boolean(state.draftStartTime) &&
+    Boolean(state.draftEndTime) &&
+    state.draftStartTime < state.draftEndTime;
+  const canRegister = selectedDateSlots.length > 0;
+
+  const selectDate = (date: Date) => {
+    setState((prev) => ({
+      ...prev,
+      selectedDate: date,
+      currentMonth: isSameMonth(date, prev.currentMonth) ? prev.currentMonth : date,
+      ...clearSlotDraft(),
+    }));
+  };
+
+  const addOrUpdateSlot = () => {
+    if (!canSubmitSlot) {
+      return;
+    }
+
+    setState((prev) => {
+      if (prev.editingSlotId) {
+        return {
+          ...prev,
+          slots: prev.slots.map((slot) =>
+            slot.id === prev.editingSlotId
+              ? {
+                  ...slot,
+                  dateKey: dateKeyOf(prev.selectedDate),
+                  startTime: prev.draftStartTime,
+                  endTime: prev.draftEndTime,
+                }
+              : slot,
+          ),
+          ...clearSlotDraft(),
+        };
+      }
+
+      return {
+        ...prev,
+        slots: [
+          ...prev.slots,
+          {
+            id: createSlotId(),
+            dateKey: dateKeyOf(prev.selectedDate),
+            startTime: prev.draftStartTime,
+            endTime: prev.draftEndTime,
+          },
+        ],
+        ...clearSlotDraft(),
+      };
+    });
+  };
+
+  const registerSchedule = () => {
+    if (!canRegister) {
+      return;
+    }
+
+    setState((prev) => ({ ...prev, toastVisible: true }));
+    window.setTimeout(() => {
+      setState((prev) => ({ ...prev, toastVisible: false }));
+    }, 1800);
+  };
+
+  const goToPrevMonth = () =>
+    setState((prev) => ({ ...prev, currentMonth: subMonths(prev.currentMonth, 1) }));
+  const goToNextMonth = () =>
+    setState((prev) => ({ ...prev, currentMonth: addMonths(prev.currentMonth, 1) }));
+  const updateDraftStartTime = (value: string) =>
+    setState((prev) => ({ ...prev, draftStartTime: value }));
+  const updateDraftEndTime = (value: string) =>
+    setState((prev) => ({ ...prev, draftEndTime: value }));
+  const startEditSlot = (slot: TimeSlot) =>
+    setState((prev) => ({
+      ...prev,
+      draftStartTime: slot.startTime,
+      draftEndTime: slot.endTime,
+      editingSlotId: slot.id,
+    }));
+  const removeSlot = (slotId: string) =>
+    setState((prev) => ({
+      ...prev,
+      slots: prev.slots.filter((slot) => slot.id !== slotId),
+      ...(prev.editingSlotId === slotId ? clearSlotDraft() : {}),
+    }));
+  const toggleGroupMentoring = () =>
+    setState((prev) => ({ ...prev, isGroupMentoring: !prev.isGroupMentoring }));
+  const decrementCapacity = () =>
+    setState((prev) => ({ ...prev, capacity: Math.max(1, prev.capacity - 1) }));
+  const incrementCapacity = () =>
+    setState((prev) => ({ ...prev, capacity: Math.min(5, prev.capacity + 1) }));
+
+  const calendar = {
+    currentMonth: state.currentMonth,
+    calendarDays,
+    selectDate,
+    goToPrevMonth,
+    goToNextMonth,
+  };
+  const dateNav = {
+    selectedDateLabel,
+    selectPrevDate: () => selectDate(addDays(state.selectedDate, -1)),
+    selectNextDate: () => selectDate(addDays(state.selectedDate, 1)),
+  };
+  const timeSlot = {
+    selectedDateSlots,
+    draftStartTime: state.draftStartTime,
+    draftEndTime: state.draftEndTime,
+    editingSlotId: state.editingSlotId,
+    canSubmitSlot,
+    updateDraftStartTime,
+    updateDraftEndTime,
+    addOrUpdateSlot,
+    startEditSlot,
+    removeSlot,
+  };
+  const groupMentoring = {
+    isGroupMentoring: state.isGroupMentoring,
+    capacity: state.capacity,
+    toggleGroupMentoring,
+    decrementCapacity,
+    incrementCapacity,
+  };
+  const register = {
+    canRegister,
+    toastVisible: state.toastVisible,
+    registerSchedule,
+  };
+
+  return {
+    calendar,
+    dateNav,
+    timeSlot,
+    groupMentoring,
+    register,
+  };
+}

--- a/src/components/mypage/ob/schedule/types.ts
+++ b/src/components/mypage/ob/schedule/types.ts
@@ -1,0 +1,78 @@
+export type TimeSlot = {
+  id: string;
+  dateKey: string;
+  startTime: string;
+  endTime: string;
+};
+
+export type CalendarDay = {
+  date: Date;
+  dateKey: string;
+  day: number;
+  isCurrentMonth: boolean;
+  isSelected: boolean;
+  isToday: boolean;
+  isSunday: boolean;
+  hasSlots: boolean;
+};
+
+export type ObScheduleState = {
+  currentMonth: Date;
+  selectedDate: Date;
+  slots: TimeSlot[];
+  draftStartTime: string;
+  draftEndTime: string;
+  editingSlotId: string | null;
+  isGroupMentoring: boolean;
+  capacity: number;
+  toastVisible: boolean;
+};
+
+export type ScheduleCalendarModel = {
+  currentMonth: Date;
+  calendarDays: CalendarDay[];
+  selectDate: (date: Date) => void;
+  goToPrevMonth: () => void;
+  goToNextMonth: () => void;
+};
+
+export type ScheduleDateNavModel = {
+  selectedDateLabel: string;
+  selectPrevDate: () => void;
+  selectNextDate: () => void;
+};
+
+export type ScheduleTimeSlotModel = {
+  selectedDateSlots: TimeSlot[];
+  draftStartTime: string;
+  draftEndTime: string;
+  editingSlotId: string | null;
+  canSubmitSlot: boolean;
+  updateDraftStartTime: (value: string) => void;
+  updateDraftEndTime: (value: string) => void;
+  addOrUpdateSlot: () => void;
+  startEditSlot: (slot: TimeSlot) => void;
+  removeSlot: (slotId: string) => void;
+};
+
+export type ScheduleGroupMentoringModel = {
+  isGroupMentoring: boolean;
+  capacity: number;
+  toggleGroupMentoring: () => void;
+  decrementCapacity: () => void;
+  incrementCapacity: () => void;
+};
+
+export type ScheduleRegisterModel = {
+  canRegister: boolean;
+  toastVisible: boolean;
+  registerSchedule: () => void;
+};
+
+export type UseObScheduleReturn = {
+  calendar: ScheduleCalendarModel;
+  dateNav: ScheduleDateNavModel;
+  timeSlot: ScheduleTimeSlotModel;
+  groupMentoring: ScheduleGroupMentoringModel;
+  register: ScheduleRegisterModel;
+};

--- a/src/components/mypage/ob/schedule/utils.ts
+++ b/src/components/mypage/ob/schedule/utils.ts
@@ -1,0 +1,55 @@
+import {
+  addDays,
+  format,
+  getDate,
+  getDay,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { scheduleTodayDate } from "@/components/mypage/ob/schedule/constants";
+import type { CalendarDay, TimeSlot } from "@/components/mypage/ob/schedule/types";
+
+export const dateKeyOf = (date: Date) => format(date, "yyyy-MM-dd");
+
+export const createSlotId = () =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export const clearSlotDraft = () => ({
+  draftStartTime: "",
+  draftEndTime: "",
+  editingSlotId: null,
+});
+
+export const buildCalendarDays = ({
+  currentMonth,
+  selectedDate,
+  slots,
+}: {
+  currentMonth: Date;
+  selectedDate: Date;
+  slots: TimeSlot[];
+}): CalendarDay[] => {
+  const monthStart = startOfMonth(currentMonth);
+  const gridStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+  const slotDateKeys = new Set(slots.map((slot) => slot.dateKey));
+
+  return Array.from({ length: 35 }, (_, index) => {
+    const date = addDays(gridStart, index);
+    const dateKey = dateKeyOf(date);
+
+    return {
+      date,
+      dateKey,
+      day: getDate(date),
+      isCurrentMonth: isSameMonth(date, currentMonth),
+      isSelected: isSameDay(date, selectedDate),
+      isToday: isSameDay(date, scheduleTodayDate),
+      isSunday: getDay(date) === 0,
+      hasSlots: slotDateKeys.has(dateKey),
+    };
+  });
+};

--- a/src/components/mypage/ob/types.ts
+++ b/src/components/mypage/ob/types.ts
@@ -46,7 +46,7 @@ export type ObMentoringPresenterProps = UseObMentoringFormReturn;
 export type SideNavItem = {
   label: string;
   icon: LucideIcon;
-  active?: boolean;
+  href?: string;
 };
 
 export type SectionProps = {

--- a/src/components/shared/ui/SuccessToast.tsx
+++ b/src/components/shared/ui/SuccessToast.tsx
@@ -1,12 +1,16 @@
 import { Check } from "lucide-react";
 
-export function SaveToast() {
+type SuccessToastProps = {
+  message?: string;
+};
+
+export function SuccessToast({ message = "수정이 완료되었습니다." }: SuccessToastProps) {
   return (
     <div className="fixed bottom-10 left-1/2 z-50 flex min-h-12 -translate-x-1/2 items-center gap-1.5 overflow-hidden rounded-full bg-[#1b1c1e]/[0.52] px-4 py-2 text-[15px] font-semibold leading-[22px] tracking-[0.144px] text-white/90 shadow-lg backdrop-blur-[32px] before:absolute before:inset-0 before:bg-[#0066ff]/5">
       <span className="relative grid size-6 shrink-0 place-items-center rounded-full bg-[#18c568]">
         <Check size={15} strokeWidth={3} className="text-white" />
       </span>
-      <span className="relative px-0.5 py-[5px]">수정이 완료되었습니다.</span>
+      <span className="relative px-0.5 py-[5px]">{message}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `/mypage/ob/schedule` 일정 등록 페이지를 추가했습니다.
- OB SideNav를 라우트 이동/active prop 기반으로 정리했습니다.
- 성공 toast를 `shared/ui/SuccessToast`로 공용화했습니다.
- 긴 dropdown 옵션 목록이 스크롤되도록 전역 스타일을 보강했습니다.

## Test
- `pnpm lint`
- `pnpm build`

## Note
- API 연동 없이 로컬 상태 기반으로 구현했습니다.
- 작업과 무관한 `.gitignore`의 `.gstack/` 변경은 커밋에 포함하지 않았습니다.